### PR TITLE
Base transformers

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,3 @@
+{
+  "esnext": true
+}

--- a/src/defaultrenderer.js
+++ b/src/defaultrenderer.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import {RendererBase} from './rendererbase';
+
+export class DefaultRenderer extends RendererBase {
+    get mimetype() {
+        return 'unknown';
+    }
+
+    render(data) {
+        var el = document.createElement('div');
+        el.textContent = JSON.stringify(data);
+        return el;
+    }
+}

--- a/src/htmlrenderer.js
+++ b/src/htmlrenderer.js
@@ -1,0 +1,16 @@
+"use strict";
+
+import {RendererBase} from './rendererbase';
+
+export class HTMLRenderer extends RendererBase {
+    get mimetype() {
+        return 'text/html';
+    }
+
+    render(data) {
+        var el = document.createElement('div');
+        // TODO: Pull scripts from inside, create elements for them
+        el.innerHTML = data;
+        return el;
+    }
+}

--- a/src/rendererbase.js
+++ b/src/rendererbase.js
@@ -1,0 +1,11 @@
+"use strict";
+
+export class RendererBase {
+    get mimetype() {
+        throw new Error('mimetype not implemented');
+    }
+
+    render(data, metadata) {
+        throw new Error('render not implemented');
+    }
+}

--- a/src/textrenderer.js
+++ b/src/textrenderer.js
@@ -1,0 +1,15 @@
+"use strict";
+
+import {RendererBase} from './rendererbase';
+
+export class TextRenderer extends RendererBase {
+    get mimetype() {
+        return 'text/plain';
+    }
+
+    render(data) {
+        var el = document.createElement('div');
+        el.textContent = data;
+        return el;
+    }
+}

--- a/src/transformime.js
+++ b/src/transformime.js
@@ -1,3 +1,4 @@
+"use strict";
 
 /**
  * Transforms mimetypes into HTMLElements
@@ -8,7 +9,7 @@ class Transformime {
      * Public constructor
      */
     constructor() {
-    
+
         // Initialize instance variables.
         this.renderers = [
             new TextRenderer(),
@@ -19,7 +20,7 @@ class Transformime {
 
     transformMimeBundle(bundle) {
         this._validateMimebundle(bundle);
-        
+
         let element;
         let richRenderer = this.fallbackRenderer;
 


### PR DESCRIPTION
This brings in the "renderers" from jupyter-display-area.

They should probably get renamed as transformers.