### PR TITLE
export default to enable short require

### DIFF
--- a/src/transformime.js
+++ b/src/transformime.js
@@ -8,7 +8,7 @@ import {HTMLRenderer} from './htmlrenderer';
 /**
  * Transforms mimetypes into HTMLElements
  */
-export class Transformime {
+export default class Transformime {
 
     /**
      * Public constructor


### PR DESCRIPTION
This changes the usage from

```javascript
let Transformime = require('transformime').Transformime;
```

to

```javascript
let Transformime = require('transformime');
```