### PR TITLE
Return mimetypes

### DIFF
--- a/src/transformime.js
+++ b/src/transformime.js
@@ -49,8 +49,10 @@ class Transformime {
 
         if (richTransformer){
             let mimetype = richTransformer.mimetype;
-            let data = bundle[mimetype];
-            return {mimetype: this.transform(data, mimetype, doc)};
+            var prom = this.transform(bundle[mimetype], mimetype, doc);
+            return prom.then(el => {
+                return Promise.resolve({mimetype: el});
+            });
         }
 
         return Promise.reject(new Error('Transformer(s) for ' + Object.keys(bundle).join(', ') + ' not found.'));
@@ -65,7 +67,10 @@ class Transformime {
     transformAll(bundle, doc) {
         var mimetypes = Object.keys(bundle);
         var promises = mimetypes.map( mimetype => {
-            return {mimetype: this.transform(bundle[mimetype], mimetype, doc)};
+            var prom = this.transform(bundle[mimetype], mimetype, doc);
+            return prom.then(el => {
+                return Promise.resolve({mimetype: el});
+            });
         });
         return Promise.all(promises);
     }

--- a/src/transformime.js
+++ b/src/transformime.js
@@ -48,8 +48,9 @@ class Transformime {
         }
 
         if (richTransformer){
-            let data = bundle[richTransformer.mimetype];
-            return this.transform(data, richTransformer.mimetype, doc);
+            let mimetype = richTransformer.mimetype;
+            let data = bundle[mimetype];
+            return {mimetype: this.transform(data, mimetype, doc)};
         }
 
         return Promise.reject(new Error('Transformer(s) for ' + Object.keys(bundle).join(', ') + ' not found.'));
@@ -63,7 +64,9 @@ class Transformime {
      */
     transformAll(bundle, doc) {
         var mimetypes = Object.keys(bundle);
-        var promises = mimetypes.map( mimetype => { return this.transform(bundle[mimetype], mimetype, doc); });
+        var promises = mimetypes.map( mimetype => {
+            return {mimetype: this.transform(bundle[mimetype], mimetype, doc)};
+        });
         return Promise.all(promises);
     }
 

--- a/src/transformime.js
+++ b/src/transformime.js
@@ -49,13 +49,20 @@ class Transformime {
 
         if (richTransformer){
             let mimetype = richTransformer.mimetype;
-            var prom = this.transform(bundle[mimetype], mimetype, doc);
-            return prom.then(el => {
-                return Promise.resolve({mimetype: el});
-            });
+            return this.transformRetainMimetype(bundle[mimetype], mimetype, doc);
         }
 
         return Promise.reject(new Error('Transformer(s) for ' + Object.keys(bundle).join(', ') + ' not found.'));
+    }
+
+    transformRetainMimetype(data, mimetype, doc) {
+        var prom = this.transform(data, mimetype, doc);
+        return prom.then(el => {
+            return Promise.resolve({
+                "mimetype": mimetype,
+                "el": el
+            });
+        });
     }
 
     /**
@@ -67,10 +74,7 @@ class Transformime {
     transformAll(bundle, doc) {
         var mimetypes = Object.keys(bundle);
         var promises = mimetypes.map( mimetype => {
-            var prom = this.transform(bundle[mimetype], mimetype, doc);
-            return prom.then(el => {
-                return Promise.resolve({mimetype: el});
-            });
+            return this.transformRetainMimetype(bundle[mimetype], mimetype, doc);
         });
         return Promise.all(promises);
     }

--- a/src/transformime.js
+++ b/src/transformime.js
@@ -58,10 +58,10 @@ class Transformime {
     transformRetainMimetype(data, mimetype, doc) {
         var prom = this.transform(data, mimetype, doc);
         return prom.then(el => {
-            return Promise.resolve({
+            return {
                 "mimetype": mimetype,
                 "el": el
-            });
+            };
         });
     }
 

--- a/test/transformime.test.js
+++ b/test/transformime.test.js
@@ -103,10 +103,13 @@ describe('Transformime', function() {
                 };
 
                 var elPromise = this.t.transformRichest(mimeBundle, this.document);
-                return elPromise.then( () => {
+                return elPromise.then( (mimel) => {
                     assert.isUndefined(this.dummyTransformer1.lastData);
                     assert.isUndefined(this.dummyTransformer2.lastData);
                     assert.equal(this.dummyTransformer3.lastData, "dummy data 3");
+
+                    assert.equal(mimel.mimetype, "transformime/dummy3");
+                    assert.equal(mimel.el.textContent, "dummy data 3");
                 });
 
             });
@@ -164,10 +167,27 @@ describe('Transformime', function() {
             };
 
             var elPromise = this.t.transformAll(mimeBundle, this.document);
-            return elPromise.then( () => {
+            return elPromise.then( (els) => {
                 assert.equal(this.dummyTransformer1.lastData, "dummy data 1");
                 assert.equal(this.dummyTransformer2.lastData, "dummy data 2");
                 assert.equal(this.dummyTransformer3.lastData, "dummy data 3");
+
+                els.map(mimel => {
+
+                    switch (mimel.mimetype){
+                        case "transformime/dummy1":
+                            assert.equal("dummy data 1", mimel.el.textContent);
+                            break;
+                        case "transformime/dummy2":
+                            assert.equal("dummy data 2", mimel.el.textContent);
+                            break;
+                        case "transformime/dummy3":
+                            assert.equal("dummy data 3", mimel.el.textContent);
+                            break;
+                    }
+
+                });
+
             });
 
         });


### PR DESCRIPTION
This changes `transformRichest` and `transformAll` to return an Array of promises that resolve to

```
{
  "mimetype": mimetype,
  "el": element
}
```

I'll need to update the README if we like this.

/cc @jdfreder 