### PR TITLE
Fully adhere to JS standard style.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,0 @@
-{
-  "esnext": true,
-  "node": true
-}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "nodemon": "^1.3.7",
     "parallelshell": "^1.2.0",
     "rimraf": "^2.4.1",
-    "standard": "^5.0.2"
+    "standard": "^5.3.1"
   }
 }

--- a/src/transformime.js
+++ b/src/transformime.js
@@ -20,7 +20,6 @@ class Transformime {
     this.push(HTMLTransformer)
     if (transformers) transformers.map((transformer) => this.push(transformer))
   }
-
   /**
    * Transforms a mime bundle, using the richest available representation,
    * into an HTMLElement.
@@ -29,7 +28,6 @@ class Transformime {
    * @return {Promise<{mimetype: string, el: HTMLElement}>}
    */
   transform (bundle, document) {
-
     if (this.transformers.length <= 0) {
       // Empty transformers
       return Promise.reject(new Error('No transformers configured'))
@@ -74,7 +72,6 @@ class Transformime {
     } else {
       return Promise.reject(new Error('Transformer(s) for ' + Object.keys(bundle).join(', ') + ' not found.'))
     }
-
   }
 
   /**
@@ -179,7 +176,7 @@ class Transformime {
    * @return {function} transformer
    */
   _proxy (transformer, mimetype) {
-    let transform = function (...args) {return transformer.call(this, ...args)}
+    let transform = function (...args) { return transformer.call(this, ...args) }
     transform.mimetype = mimetype
     return transform
   }

--- a/test/transformime.test.js
+++ b/test/transformime.test.js
@@ -52,7 +52,6 @@ describe('Transformime', function () {
         // real document.
         assert(results.el instanceof this.document.defaultView.HTMLElement)
       })
-
     })
     it('should fail when the mimetype is not known', function () {
       let elPromise = this.t.transform({'transformime/unknown': 'my-data'}, this.doc)
@@ -76,7 +75,6 @@ describe('Transformime', function () {
           assert.equal(results.mimetype, 'transformime/dummy3')
           assert.equal(results.el.textContent, 'dummy data 3')
         })
-
       })
       it('when called with a lesser mimebundle, choose most rich', function () {
         let mimeBundle = {


### PR DESCRIPTION
Bringing in #31 broke tests. This resolves it.

I'm kind of annoyed at having both my plugin for jshint and standard set. I can't straddle them both in Atom. It's one or the other, no deciding between. Is there a jshintrc for standard, @karissa? I realize the project vision is no jshintrc or eshintrc, but it also flies in the face of working with other code bases that *do* use them.