### PR TITLE
Rely on the Blob and ObjectURL API.

### DIFF
--- a/src/html.transformer.js
+++ b/src/html.transformer.js
@@ -1,10 +1,7 @@
 'use strict'
 
 export function HTMLTransformer (mimetype, data, document) {
-  var em = document.createElement('embed')
-  var URL = document.defaultView.URL
-  var Blob = document.defaultView.Blob
-  em.src = URL.createObjectURL(new Blob([data], {type: mimetype}))
-  return em
+  var range = document.createRange()
+  return range.createContextualFragment(data)
 }
 HTMLTransformer.mimetype = 'text/html'

--- a/src/html.transformer.js
+++ b/src/html.transformer.js
@@ -1,9 +1,10 @@
 'use strict'
 
 export function HTMLTransformer (mimetype, data, document) {
-  var el = document.createElement('div')
-  // TODO: Pull scripts from inside, create elements for them
-  el.innerHTML = data
-  return el
+  var em = document.createElement('embed')
+  var URL = document.defaultView.URL
+  var Blob = document.defaultView.Blob
+  em.src = URL.createObjectURL(new Blob([data], {type: mimetype}))
+  return em
 }
 HTMLTransformer.mimetype = 'text/html'


### PR DESCRIPTION
This makes use of the [Blob API](https://developer.mozilla.org/en-US/docs/Web/API/Blob) and [`URL.createObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) to create well formed, fully parsed and executed blocks of HTML.