### PR TITLE
use forEach instead of map

### DIFF
--- a/src/transformime.js
+++ b/src/transformime.js
@@ -18,7 +18,7 @@ class Transformime {
     this.push(TextTransform)
     this.push(ImageTransform)
     this.push(HTMLTransform)
-    if (transformers) transformers.map((transformer) => this.push(transformer))
+    if (transformers) transformers.forEach((transformer) => { this.push(transformer) })
   }
   /**
    * Transforms a mime bundle, using the richest available representation,


### PR DESCRIPTION
`Array.map` is used to transform one array into another array. It shouldn't be used for side-effect-only iteration. `Array.forEach` is the proper method to use here, and avoids the extra array allocation done by `map`.