### PR TITLE
Add helper function createTransform

### DIFF
--- a/src/transformime.js
+++ b/src/transformime.js
@@ -182,6 +182,30 @@ class Transformime {
   }
 }
 
+/**
+* Helper to create a function that transforms a MIME bundle into an HTMLElement
+* using the given document and list of transformers.
+* @param  {function[]} [transformers] List of transformers, in reverse priority order.
+* @param  {Document}   [doc]          E.g. window.document, iframe.contentDocument
+* @return {function}
+*/
+function createTransform (transformers, doc) {
+  const t = new Transformime(transformers)
+
+  if (!doc) {
+      doc = document
+  }
+
+  /**
+   * Transforms a MIME bundle into an HTMLElement.
+   * @param  {object} bundle {mimetype1: data1, mimetype2: data2, ...}
+   * @return {Promise<{mimetype: string, el: HTMLElement}>}
+   */
+  return function transform(bundle) {
+    return t.transform(bundle, doc)
+  }
+}
+
 export {
     Transformime,
     TextTransform,
@@ -189,5 +213,6 @@ export {
     ImageTransform,
     ImageTransform as ImageTransformer,
     HTMLTransform,
-    HTMLTransform as HTMLTransformer
+    HTMLTransform as HTMLTransformer,
+    createTransform
 };

--- a/test/transformime.test.js
+++ b/test/transformime.test.js
@@ -1,6 +1,7 @@
 /* global describe it beforeEach before */
 var test = require('tape')
 var Transformime = require('../src/transformime').Transformime
+var createTransform = require('../src/transformime').createTransform
 
 /**
 * Dummy Transformer for spying on
@@ -109,4 +110,23 @@ test('get respects priority order', function (t) {
   let transformer = tf.get('transformime/a')
   t.equal(dummyTransformer5, transformer)
   t.end()
+})
+
+test('createTransform returns a transform function for our dummyTransformer', function (t) {
+  function dummyTransformer(mimetype, data, document) {
+    dummyTransformer.doc = document
+    let div = document.createElement('div')
+    div.innerHTML = data
+    return div
+  }
+  dummyTransformer.mimetype = 'transformime/dummy'
+
+  var transform = createTransform([dummyTransformer])
+
+  transform({'transformime/dummy': 'dummy-data'}).then((result) => {
+    t.equal(dummyTransformer.doc, document)
+    t.equal(result.mimetype, 'transformime/dummy')
+    t.equal(result.el.innerHTML, 'dummy-data')
+    t.end()
+  })
 })


### PR DESCRIPTION
Added a helper function for the most common use cases; e.g.

```js
var transformime = require("transformime");
var transformimeJupyter = require("transformime-jupyter-transformers")

var transform = transformime.createTransform([
    transformime.TextTransformer,
    transformimeJupyter.PDFTransform,
    transformime.ImageTransformer,
    transformimeJupyter.SVGTransform,
    transformimeJupyter.consoleTextTransform,
    transformimeJupyter.LaTeXTransform,
    transformimeJupyter.markdownTransform,
    transformime.HTMLTransformer,
    transformimeJupyter.ScriptTransform
]);

transform({
    "text/plain": "Hello, World!",
}).then(function(result) {
    mimetype = result.mimetype;
    htmlElement = result.el;
   // ...
});
```