### PR TITLE
Fix pdf test for firefox

### DIFF
--- a/test/html.transform.test.js
+++ b/test/html.transform.test.js
@@ -24,7 +24,7 @@ tape('should execute script tag', function (t) {
   var htmlText = '<script>window.y=3;</script>'
   return tf.transform({'text/html': htmlText}, document).then(results => {
     document.body.appendChild(results.el)
-    t.equals(window.y, 3, 'this will fail on safari and firefox')
+    t.equals(window.y, 3, 'this will fail on safari')
     t.end()
   })
 })

--- a/test/pdf.transform.test.js
+++ b/test/pdf.transform.test.js
@@ -18,11 +18,14 @@ tape('should have the application/pdf mimetype', function (t) {
 
 tape('should create an link to the pdf file', function (t) {
   beforeEach()
-  let base64PDF = "I don't have a b64'd PDF"
+  let base64PDF = "SOMEBASE64PDF"
   let transformed = tf.transform({'application/pdf': base64PDF}, document)
-  let html = '<a target="_blank" href="data:application/pdf;base64,I don\'t have a b64\'d PDF">View PDF</a>'
+  let html = '<a target="_blank" href="data:application/pdf;base64,SOMEBASE64PDF">View PDF</a>'
   return transformed.then( result => {
-    t.equal(result.el.outerHTML, html)
+    t.equal(result.el.localName, 'a')
+    t.equal(result.el.target, '_blank')
+    t.equal(result.el.href, 'data:application/pdf;base64,SOMEBASE64PDF')
+    t.equal(result.el.innerHTML, 'View PDF')
     t.end()
   })
 })


### PR DESCRIPTION
Firefox outputs:
`<a href="data:application/pdf;base64,I don\'t have a b64\'d PDF" target="_blank" >View PDF</a>`
compared to chrome:
`<a target="_blank" href="data:application/pdf;base64,I don\'t have a b64\'d PDF" >View PDF</a>`