### PR TITLE
Remove broken transformer exports

### DIFF
--- a/src/transformime.js
+++ b/src/transformime.js
@@ -225,14 +225,9 @@ export {
     HTMLTransform,
     HTMLTransform as HTMLTransformer,
     SVGTransform,
-    SVGTransform as SVGTransform,
     PDFTransform,
-    PDFTransform as PDFTransform,
     ScriptTransform,
-    ScriptTransform as ScriptTransform,
     LaTeXTransform,
-    LaTeXTransform as LaTeXTransform,
     MarkdownTransform,
-    MarkdownTransform as MarkdownTransform,
     createTransform
 };


### PR DESCRIPTION
Closes #69 

Should we also remove the deprecated alternative exports `TextTransformer`, `ImageTransformer` and `HTMLTransformer`?